### PR TITLE
[18] API - 유저 문서 목록 가져오기

### DIFF
--- a/src/api/controllers/users.controllers.js
+++ b/src/api/controllers/users.controllers.js
@@ -21,3 +21,15 @@ exports.join = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.getDocs = async (req, res, next) => {
+  try {
+    const docs = await usersService.getUserDocs(res.locals.user);
+    res.json({
+      result: "ok",
+      docs: docs,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/api/routes/users.js
+++ b/src/api/routes/users.js
@@ -5,5 +5,6 @@ const usersController = require("../controllers/users.controllers");
 const validator = require("../middlewares/validator");
 
 router.post("/", validator.verifyEmail, usersController.join);
+router.get("/docs", validator.verifyAccessToken, usersController.getDocs);
 
 module.exports = router;

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -21,3 +21,10 @@ exports.findUser = async (email) => {
   const user = await User.findOne({ email }, "_id").lean();
   return user ? user : null;
 };
+
+exports.getUserDocs = async (email) => {
+  const { docs } = await User.findOne({ email }, "docs")
+    .lean()
+    .populate("docs", "-body -createdBy -__v");
+  return docs;
+};

--- a/src/models/Doc.js
+++ b/src/models/Doc.js
@@ -11,6 +11,11 @@ const DocSchema = new Schema(
       type: String,
       default: "",
     },
+    summary: {
+      type: String,
+      default: "",
+      maxlength: 500,
+    },
     createdBy: {
       type: Schema.Types.ObjectId,
       ref: "User",


### PR DESCRIPTION
# [18] API - 유저 문서 목록 가져오기

## 노션 칸반 링크

- [[18] API - 유저 문서 목록 가져오기](https://www.notion.so/lazymole/API-GET-eeae84a40d3245dfbfccd837363fb089)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: Doc 모델 summary 필드 추가
- Feat: /api/users/docs 라우터 추가
- Feat: 문서 목록 가져오기 관련 컨트롤러, 서비스 로직 추가
