### PR TITLE
[16] API - PUT 문서 수정 후 저장

### DIFF
--- a/src/api/controllers/docs.controllers.js
+++ b/src/api/controllers/docs.controllers.js
@@ -32,12 +32,53 @@ exports.getDetail = async (req, res, next) => {
   const docId = req.params.id;
 
   try {
-    const { body, createdBy } = await docsService.getDocDetail(docId);
+    const result = await docsService.getDocDetail(docId);
+
+    if (!result) {
+      return res.json({
+        result: "error",
+        error: "No such document",
+      });
+    }
+
+    const { body, createdBy } = result;
 
     if (createdBy.email === userEmail) {
       return res.json({
         result: "ok",
         body,
+      });
+    }
+
+    res.json({
+      result: "error",
+      error: "Unauthorized User",
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.saveDoc = async (req, res, next) => {
+  const userEmail = res.locals.user;
+  const docId = req.params.id;
+  const { body } = req.body;
+  const summary = body.slice(0, 500);
+
+  try {
+    const result = await docsService.getDocDetail(docId);
+
+    if (!result) {
+      return res.json({
+        result: "error",
+        error: "No such document",
+      });
+    }
+
+    if (result.createdBy.email === userEmail) {
+      await docsService.saveDoc({ id: docId, body, summary });
+      return res.json({
+        result: "ok",
       });
     }
 

--- a/src/api/routes/docs.js
+++ b/src/api/routes/docs.js
@@ -11,5 +11,11 @@ router.get(
   validator.verifyParams,
   docsController.getDetail
 );
+router.put(
+  "/:id",
+  validator.verifyAccessToken,
+  validator.verifyParams,
+  docsController.saveDoc
+);
 
 module.exports = router;

--- a/src/api/services/docs.service.js
+++ b/src/api/services/docs.service.js
@@ -18,3 +18,7 @@ exports.getDocDetail = async (id) => {
     .populate("createdBy", "email -_id");
   return result;
 };
+
+exports.saveDoc = async ({ id, body, summary }) => {
+  await Doc.findByIdAndUpdate(id, { body, summary });
+};


### PR DESCRIPTION
# [16] API - PUT 문서 수정 후 저장

## 노션 칸반 링크

- [[16] API - PUT 문서 수정 후 저장](https://www.notion.so/lazymole/API-PUT-c2e3000d5f824afdb4f87a491dbf08e3)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: 문서 가져오기 에러 처리 분기 추가
- Feat: 문서 수정 API 추가
- Feat: 문서 body, summary 업데이트 서비스 로직 추가
