### PR TITLE
[20] API - DELETE 문서 삭제

### DIFF
--- a/src/api/controllers/docs.controllers.js
+++ b/src/api/controllers/docs.controllers.js
@@ -95,3 +95,35 @@ exports.saveDoc = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.deleteDoc = async (req, res, next) => {
+  const userEmail = res.locals.user;
+  const docId = req.params.id;
+
+  try {
+    const result = await docsService.getDocDetail(docId);
+
+    if (!result) {
+      res.status(404);
+      return res.json({
+        result: "error",
+        error: "No such document",
+      });
+    }
+
+    if (result.createdBy.email === userEmail) {
+      await docsService.deleteDoc({ email: userEmail, id: docId });
+      return res.json({
+        result: "ok",
+      });
+    }
+
+    res.status(401);
+    res.json({
+      result: "error",
+      error: "Unauthorized User",
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/api/routes/docs.js
+++ b/src/api/routes/docs.js
@@ -17,5 +17,11 @@ router.put(
   validator.verifyParams,
   docsController.saveDoc
 );
+router.delete(
+  "/:id",
+  validator.verifyAccessToken,
+  validator.verifyParams,
+  docsController.deleteDoc
+);
 
 module.exports = router;

--- a/src/api/services/docs.service.js
+++ b/src/api/services/docs.service.js
@@ -22,3 +22,8 @@ exports.getDocDetail = async (id) => {
 exports.saveDoc = async ({ id, body, summary }) => {
   await Doc.findByIdAndUpdate(id, { body, summary });
 };
+
+exports.deleteDoc = async ({ email, id }) => {
+  await User.findOneAndUpdate({ email }, { $pull: { docs: id } });
+  await Doc.findByIdAndRemove(id);
+};


### PR DESCRIPTION
# [20] API - DELETE 문서 삭제

## 노션 칸반 링크

- [[20] API - DELETE 문서 삭제](https://www.notion.so/lazymole/API-DELETE-590c4c892df84175a6cba233d90f3618)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: 문서 삭제 API 추가
